### PR TITLE
Fixed Linking social media urls bug

### DIFF
--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -50,10 +50,18 @@ const Footer = () => {
                 })}
               </div>
               <div className="flex gap-3 text-lg">
-                <FaFacebook className="facebook"/>
-                <FaGoogle className="google"/>
-                <FaXTwitter className="twitter"/>
-                <FaYoutube className="youtube"/>
+                <a href="https://www.facebook.com" target="_blank" rel="noopener noreferrer">
+                  <FaFacebook className="facebook" />
+                </a>
+                <a href="https://www.google.com" target="_blank" rel="noopener noreferrer">
+                  <FaGoogle className="google" />
+                </a>
+                <a href="https://www.twitter.com" target="_blank" rel="noopener noreferrer">
+                  <FaXTwitter className="twitter" />
+                </a>
+                <a href="https://www.youtube.com" target="_blank" rel="noopener noreferrer">
+                  <FaYoutube className="youtube" />
+                </a>
               </div>
               <div></div>
             </div>


### PR DESCRIPTION
## Related Issue
Pull Request: Resolve Issue #82  - Social Media Icons in Footer Section Not Linked to Handles

## Description
This pull request addresses issue #82  by fixing the bug where the social media icons in the "Footer" section were not linked to their respective handles. So, I've added the **anchor tags** to each social media icon for navigating to their respective platforms. I've made my code very simple so that it doesn't require comments to understand too. 

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [x] Other (specify): _____GSSOC'24__________

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.

## Screenshot/Video Representation

![image](https://github.com/Muskansahuincredible/StudyNotion-An-Online-Education-Platform/assets/163159351/de75b268-02df-4dcc-be10-5c0342434651)
This is the part I've been working on.
https://github.com/Muskansahuincredible/StudyNotion-An-Online-Education-Platform/assets/163159351/1ab704cf-e257-4f4b-84f2-616265f03ff2
Here I've Shown the navigating part, the video is a bit cluttering due to the conversion of the MKV file to MP4, I Apologise for this inconvenience.

## Additional context:
- Please review the changes and let me know if any further modifications are required.
- Tested the changes locally and ensured proper functionality.

**Reviewer Checklist:**
- [ ] Verified that social media icons are linked correctly.
- [ ] Checked if there is no discrepancy.

---

Let me know if you need any further adjustments or if there's anything else you'd like to include!
