### PR TITLE
add counting animation at about us fix issue #265

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,7 +30,7 @@ import ViewCourse from "./pages/ViewCourse";
 import VideoDetails from "./components/core/ViewCourse/VideoDetails";
 import Instructor from "./components/core/Dashboard/InstructorDashboard/Instructor";
 import BackToTop from "./components/common/BackToTop";
-import PrivacyPolicy from "./pages/PrivacyPolicy";
+import PrivacyPolicy from "./pages/privacypolicy";
 import TermsAndConditions from "./pages/TermsAndConditions";
 import Loading from "./components/common/Loading";
 

--- a/src/components/core/AboutPage/Stats.jsx
+++ b/src/components/core/AboutPage/Stats.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import useIntersectionObserver from './useIntersectionObserver'; // Adjust the path as needed
 
-const countUp = (element, start, end, duration) => {
+const countUp = (element, start, end, duration, finalDisplay) => {
   let startTime = null;
 
   const animation = (currentTime) => {
@@ -14,6 +14,8 @@ const countUp = (element, start, end, duration) => {
 
     if (progress < 1) {
       requestAnimationFrame(animation);
+    } else {
+      element.textContent = finalDisplay; // Set final display value
     }
   };
 
@@ -25,6 +27,14 @@ const parseCountValue = (count) => {
     return parseFloat(count) * 1000;
   } else {
     return parseFloat(count);
+  }
+};
+
+const getFinalDisplay = (count) => {
+  if (count.endsWith('K')) {
+    return count;
+  } else {
+    return parseFloat(count).toLocaleString();
   }
 };
 
@@ -46,7 +56,8 @@ const StatsComponent = () => {
       elementsRef.current.forEach((element, index) => {
         const countValue = stats[index].count;
         const endValue = parseCountValue(countValue);
-        countUp(element, 0, endValue, 2000);
+        const finalDisplay = getFinalDisplay(countValue);
+        countUp(element, 0, endValue, 2000, finalDisplay);
       });
     }
   }, [isIntersecting]);

--- a/src/components/core/AboutPage/Stats.jsx
+++ b/src/components/core/AboutPage/Stats.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import useIntersectionObserver from './useIntersectionObserver'; // Adjust the path as needed
 
 const countUp = (element, start, end, duration) => {
   let startTime = null;
@@ -36,35 +37,40 @@ const StatsComponent = () => {
   ];
 
   const elementsRef = useRef([]);
+  const [isIntersecting, setElement] = useIntersectionObserver({
+    threshold: 0.5, // Adjust as needed
+  });
 
   useEffect(() => {
-    elementsRef.current.forEach((element, index) => {
-      const countValue = stats[index].count;
-      const endValue = parseCountValue(countValue);
-      countUp(element, 0, endValue, 2000);
-    });
-  }, []);
+    if (isIntersecting) {
+      elementsRef.current.forEach((element, index) => {
+        const countValue = stats[index].count;
+        const endValue = parseCountValue(countValue);
+        countUp(element, 0, endValue, 2000);
+      });
+    }
+  }, [isIntersecting]);
 
   return (
-    <div className="bg-richblack-700">
+    <div className="bg-richblack-700" ref={setElement}>
       {/* Stats */}
       <div className="flex flex-col gap-10 justify-between w-11/12 max-w-maxContent text-white mx-auto">
         <div className="grid grid-cols-2 md:grid-cols-4 text-center">
           {stats.map((data, index) => (
             <div className="flex flex-col py-8" key={index}>
               <div className="flex flex-row px-20">
-              <h1
-                className="text-[30px] font-bold text-richblack-5"
-                ref={(el) => (elementsRef.current[index] = el)}
-              >
-                {parseCountValue(data.count).toLocaleString()}
-              </h1>
-              <span className="text-[30px] font-bold text-richblack-5"> + </span>
+                <h1
+                  className="text-[30px] font-bold text-richblack-5"
+                  ref={(el) => (elementsRef.current[index] = el)}
+                >
+                  {parseCountValue(data.count).toLocaleString()}
+                </h1>
+                <span className="text-[30px] font-bold text-richblack-5"> + </span>
               </div>
               <div className="flex flex-row px-20">
-              <h2 className="font-semibold text-[16px] text-richblack-500">
-                {data.label}
-              </h2>
+                <h2 className="font-semibold text-[16px] text-richblack-500">
+                  {data.label}
+                </h2>
               </div>
             </div>
           ))}

--- a/src/components/core/AboutPage/useIntersectionObserver.js
+++ b/src/components/core/AboutPage/useIntersectionObserver.js
@@ -1,0 +1,27 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useIntersectionObserver = (options) => {
+  const [isIntersecting, setIsIntersecting] = useState(false);
+  const observerRef = useRef(null);
+
+  const setElement = (element) => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+    }
+
+    if (element) {
+      observerRef.current = new IntersectionObserver(
+        ([entry]) => {
+          setIsIntersecting(entry.isIntersecting);
+        },
+        { ...options }
+      );
+
+      observerRef.current.observe(element);
+    }
+  };
+
+  return [isIntersecting, setElement];
+};
+
+export default useIntersectionObserver;


### PR DESCRIPTION
## Related Issue
fix issue #265

## Description
Now Added a counting animation to the 'About Us' page to display values when scrolling.

## Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]

video:-

https://github.com/user-attachments/assets/46108caa-76d4-4143-a079-6b3ddb9f7e7f



## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
I am a Gssoc Contributor.