### PR TITLE
Navbar buttons

### DIFF
--- a/src/components/common/Navbar.jsx
+++ b/src/components/common/Navbar.jsx
@@ -164,7 +164,7 @@ function Navbar() {
                 <div className="flex flex-col md:flex-row items-center md:items-start gap-y-4 md:gap-y-0 md:gap-x-4">
                   <Link to="/login" onClick={closeMobileMenu}>
                     <button
-                      className={`rounded-md px-4 py-2 transition duration-300 hover:scale-95 ${
+                      className={`rounded-md px-4 w-[90px] py-2 transition duration-300 hover:scale-95 ${
                         matchRoute("/login")
                           ? "bg-richblack-800 text-white"
                           : "bg-yellow-50 text-black hover:bg-richblack-800 hover:text-white "
@@ -175,7 +175,7 @@ function Navbar() {
                   </Link>
                   <Link to="/signup" onClick={closeMobileMenu}>
                     <button
-                      className={`rounded-md px-4 py-2 transition duration-300 hover:scale-95 ${
+                      className={`rounded-md px-4 w-90 py-2 transition duration-300 hover:scale-95 ${
                         matchRoute("/signup")
                           ? "bg-richblack-800 text-white"
                           : "bg-blue-300 text-white hover:bg-richblack-800 hover:text-gray-200 "

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -129,7 +129,11 @@ module.exports = {
         maxContent: "1260px",
         maxContentTab: "650px"
       },
+      screens:{
+        md:'930px',
+      }
     },
   },
+  variants:{},
   plugins: [],
 };


### PR DESCRIPTION
## Related Issue
#325 

## Description
>Set a suitable width for the buttons
>Changed the mobile nav screen size value because the words of the buttons were going into the next line and messing up the alignment, the mobile nav mode (hamburger) appears at 930px now and this does not break any existing feature of the project


## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
