### PR TITLE
Made "Get in Touch" Form on About Page Mobile Responsive

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -525,3 +525,12 @@ details > summary::-webkit-details-marker {
   margin-bottom: 0.5rem; /* Keep the margin as specified */
   text-align: left; /* Ensure text alignment to the left */
 }
+
+@media (max-width: 340px) {
+  .form{
+    width: 16rem;
+  }
+  #phonenumber{
+    margin-left: -13px;
+  }
+}

--- a/src/components/ContactPage/ContactUsForm.jsx
+++ b/src/components/ContactPage/ContactUsForm.jsx
@@ -47,6 +47,7 @@ const ContactUsForm = () => {
     <form
       className="flex flex-col gap-7"
       onSubmit={handleSubmit(submitContactForm)}
+      style={{marginTop: "30px"}}
     >
       <div className="flex flex-col gap-5 lg:flex-row">
         <div className="flex flex-col gap-2 lg:w-[48%]">

--- a/src/components/core/AboutPage/ContactFormSection.jsx
+++ b/src/components/core/AboutPage/ContactFormSection.jsx
@@ -3,14 +3,14 @@ import ContactUsForm from "../../ContactPage/ContactUsForm";
 
 const ContactFormSection = () => {
   return (
-    <div className="mx-auto">
+    <div className="mx-auto form">
       <h1 className="text-center text-4xl font-semibold">Get in Touch</h1>
       <p className="text-center text-richblack-300 mt-3">
         We&apos;d love to hear form you. Please fill out this form.
       </p>
-      <div className="mt-12 mx-auto">
+      {/* <div className="mt-12 mx-auto"> */}
         <ContactUsForm />
-      </div>
+      {/* </div> */}
     </div>
   );
 };


### PR DESCRIPTION
## Related Issue
Issue #407 solved

## Description
Made the "Get in Touch" form on the About Page mobile responsive.

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
Before:
![image](https://github.com/user-attachments/assets/700838e2-7411-48f9-982d-d42f3d204ba0)

After:
![image](https://github.com/user-attachments/assets/dcf046a5-d274-4342-a02c-c0e1e1e10cbe)

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->